### PR TITLE
Refactor de casi todo el ejemplo

### DIFF
--- a/src/main/java/ar/edu/unq/unidad3/modelo/Item.java
+++ b/src/main/java/ar/edu/unq/unidad3/modelo/Item.java
@@ -1,11 +1,18 @@
 package ar.edu.unq.unidad3.modelo;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 import lombok.*;
 
 import static jakarta.persistence.GenerationType.AUTO;
 
-@Getter @Setter @NoArgsConstructor @EqualsAndHashCode @ToString
+@Getter
+@Setter
+@NoArgsConstructor
+@EqualsAndHashCode
+@ToString
 
 @Entity
 public final class Item {
@@ -17,9 +24,9 @@ public final class Item {
     private Integer peso;
 
     @ManyToOne
-    private Personaje owner;
+    private Personaje poseedor;
 
-    public Item(@NonNull String nombre,  @NonNull Integer peso) {
+    public Item(@NonNull String nombre, @NonNull Integer peso) {
         this.nombre = nombre;
         this.peso = peso;
     }

--- a/src/main/java/ar/edu/unq/unidad3/modelo/Item.java
+++ b/src/main/java/ar/edu/unq/unidad3/modelo/Item.java
@@ -11,7 +11,6 @@ import static jakarta.persistence.GenerationType.AUTO;
 @Getter
 @Setter
 @NoArgsConstructor
-@EqualsAndHashCode
 @ToString
 
 @Entity

--- a/src/main/java/ar/edu/unq/unidad3/modelo/Personaje.java
+++ b/src/main/java/ar/edu/unq/unidad3/modelo/Personaje.java
@@ -1,15 +1,18 @@
 package ar.edu.unq.unidad3.modelo;
 
 import ar.edu.unq.unidad3.modelo.exception.MuchoPesoException;
+import jakarta.persistence.*;
 import lombok.*;
 
-import jakarta.persistence.*;
 import java.util.HashSet;
 import java.util.Set;
 
-import static jakarta.persistence.GenerationType.*;
+import static jakarta.persistence.GenerationType.AUTO;
 
-@Getter @Setter @NoArgsConstructor @ToString
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
 
 @Entity
 public class Personaje {
@@ -23,12 +26,10 @@ public class Personaje {
     private Integer vida;
     private Integer pesoMaximo;
 
-    @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "poseedor", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     private Set<Item> inventario = new HashSet<>();
 
-
-
-    public Personaje(@NonNull String nombre, @NonNull Integer vida,  @NonNull Integer pesoMaximo) {
+    public Personaje(@NonNull String nombre, @NonNull Integer vida, @NonNull Integer pesoMaximo) {
         this.nombre = nombre;
         this.vida = vida;
         this.pesoMaximo = pesoMaximo;
@@ -44,7 +45,7 @@ public class Personaje {
             throw new MuchoPesoException(this, item);
         }
         this.inventario.add(item);
-        item.setOwner(this);
+        item.setPoseedor(this);
     }
 
 }

--- a/src/main/java/ar/edu/unq/unidad3/persistencia/dao/ItemDAO.java
+++ b/src/main/java/ar/edu/unq/unidad3/persistencia/dao/ItemDAO.java
@@ -1,15 +1,25 @@
 package ar.edu.unq.unidad3.persistencia.dao;
 
 import ar.edu.unq.unidad3.modelo.Item;
+
 import java.util.Collection;
 
 public interface ItemDAO {
-    Collection<Item> getAll();
-    Item getHeaviestItem();
-    void guardar(Item item);
+    void crear(Item item);
+
+    void actualizar(Item item);
+
     Item recuperar(Long id);
+
+    Collection<Item> recuperarTodos();
+
+    Item getMasPesado();
+
     Collection<Item> getMasPesados(int peso);
+
     Collection<Item> getItemsDePersonajesDebiles(int unaVida);
+
     void eliminar(Item item);
+
     void eliminarTodo();
 }

--- a/src/main/java/ar/edu/unq/unidad3/persistencia/dao/PersonajeDAO.java
+++ b/src/main/java/ar/edu/unq/unidad3/persistencia/dao/PersonajeDAO.java
@@ -1,11 +1,14 @@
 package ar.edu.unq.unidad3.persistencia.dao;
 
-import ar.edu.unq.unidad3.modelo.Item;
 import ar.edu.unq.unidad3.modelo.Personaje;
 
 public interface PersonajeDAO {
-    void guardar(Personaje personaje);
+    void crear(Personaje personaje);
+
+    void actualizar(Personaje personaje);
+
     Personaje recuperar(Long id);
+
     void eliminar(Personaje personaje);
 
     void eliminarTodo();

--- a/src/main/java/ar/edu/unq/unidad3/persistencia/dao/impl/HibernateDAO.java
+++ b/src/main/java/ar/edu/unq/unidad3/persistencia/dao/impl/HibernateDAO.java
@@ -11,9 +11,14 @@ public class HibernateDAO<T> {
         this.entityType = entityType;
     }
 
-    public void guardar(T entity) {
+    public void crear(T entity) {
         Session session = HibernateSessionContext.getCurrentSession();
-        session.save(entity);
+        session.persist(entity);
+    }
+
+    public void actualizar(T entity) {
+        Session session = HibernateSessionContext.getCurrentSession();
+        session.merge(entity);
     }
 
     public T recuperar(Long id) {
@@ -25,6 +30,7 @@ public class HibernateDAO<T> {
         Session session = HibernateSessionContext.getCurrentSession();
         session.remove(entity);
     }
+
     public void eliminarTodo() {
         Session session = HibernateSessionContext.getCurrentSession();
         session.createQuery("delete from " + entityType.getSimpleName()).executeUpdate();

--- a/src/main/java/ar/edu/unq/unidad3/persistencia/dao/impl/HibernateItemDAO.java
+++ b/src/main/java/ar/edu/unq/unidad3/persistencia/dao/impl/HibernateItemDAO.java
@@ -1,7 +1,7 @@
 package ar.edu.unq.unidad3.persistencia.dao.impl;
 
-import ar.edu.unq.unidad3.persistencia.dao.ItemDAO;
 import ar.edu.unq.unidad3.modelo.Item;
+import ar.edu.unq.unidad3.persistencia.dao.ItemDAO;
 import ar.edu.unq.unidad3.service.runner.HibernateSessionContext;
 import org.hibernate.Session;
 import org.hibernate.query.Query;
@@ -15,11 +15,20 @@ public class HibernateItemDAO extends HibernateDAO<Item> implements ItemDAO {
     }
 
     @Override
-    public Collection<Item> getAll() {
+    public Collection<Item> recuperarTodos() {
         Session session = HibernateSessionContext.getCurrentSession();
         String hql = "select i from Item i order by i.peso asc";
         Query<Item> query = session.createQuery(hql, Item.class);
         return query.getResultList();
+    }
+
+    @Override
+    public Item getMasPesado() {
+        Session session = HibernateSessionContext.getCurrentSession();
+        String hql = "from Item i order by i.peso desc";
+        Query<Item> query = session.createQuery(hql, Item.class);
+        query.setMaxResults(1);
+        return query.getSingleResult();
     }
 
     @Override
@@ -34,18 +43,9 @@ public class HibernateItemDAO extends HibernateDAO<Item> implements ItemDAO {
     @Override
     public Collection<Item> getItemsDePersonajesDebiles(int unaVida) {
         Session session = HibernateSessionContext.getCurrentSession();
-        String hql = "from Item i where i.owner.vida < :unaVida order by i.peso asc";
+        String hql = "from Item i where i.poseedor.vida < :unaVida order by i.peso asc";
         Query<Item> query = session.createQuery(hql, Item.class);
         query.setParameter("unaVida", unaVida);
         return query.getResultList();
-    }
-
-    @Override
-    public Item getHeaviestItem() {
-        Session session = HibernateSessionContext.getCurrentSession();
-        String hql = "from Item i order by i.peso desc";
-        Query<Item> query = session.createQuery(hql, Item.class);
-        query.setMaxResults(1);
-        return query.getSingleResult();
     }
 }

--- a/src/main/java/ar/edu/unq/unidad3/persistencia/dao/impl/HibernatePersonajeDAO.java
+++ b/src/main/java/ar/edu/unq/unidad3/persistencia/dao/impl/HibernatePersonajeDAO.java
@@ -1,7 +1,7 @@
 package ar.edu.unq.unidad3.persistencia.dao.impl;
 
-import ar.edu.unq.unidad3.persistencia.dao.PersonajeDAO;
 import ar.edu.unq.unidad3.modelo.Personaje;
+import ar.edu.unq.unidad3.persistencia.dao.PersonajeDAO;
 
 public class HibernatePersonajeDAO extends HibernateDAO<Personaje> implements PersonajeDAO {
 

--- a/src/main/java/ar/edu/unq/unidad3/service/ItemService.java
+++ b/src/main/java/ar/edu/unq/unidad3/service/ItemService.java
@@ -6,14 +6,19 @@ import java.util.Collection;
 
 public interface ItemService {
 
-    void guardarItem(Item item);
-    Collection<Item> allItems();
-    void eliminarItem(Item item);
+    void crear(Item item);
+
+    void actualizar(Item item);
+
+    Collection<Item> recuperarTodos();
+
+    void eliminar(Item item);
+
     void eliminarTodos();
-    Item heaviestItem();
-    Collection<Item> getMasPesdos(int peso);
+
+    Item getMasPesado();
+
+    Collection<Item> getMasPesados(int peso);
+
     Collection<Item> getItemsPersonajesDebiles(int vida);
-
 }
-
-

--- a/src/main/java/ar/edu/unq/unidad3/service/ItemService.java
+++ b/src/main/java/ar/edu/unq/unidad3/service/ItemService.java
@@ -10,6 +10,8 @@ public interface ItemService {
 
     void actualizar(Item item);
 
+    Item recuperar(Long itemId);
+
     Collection<Item> recuperarTodos();
 
     void eliminar(Item item);

--- a/src/main/java/ar/edu/unq/unidad3/service/PersonajeService.java
+++ b/src/main/java/ar/edu/unq/unidad3/service/PersonajeService.java
@@ -1,17 +1,17 @@
 package ar.edu.unq.unidad3.service;
 
-import ar.edu.unq.unidad3.modelo.Item;
 import ar.edu.unq.unidad3.modelo.Personaje;
 
-import java.util.Collection;
-
 public interface PersonajeService {
-    void guardarPersonaje(Personaje personaje);
-    Personaje recuperarPersonaje(Long personajeId);
+    void crear(Personaje personaje);
+
+    void actualizar(Personaje personaje);
+
+    Personaje recuperar(Long personajeId);
+
     void recoger(Long personajeId, Long itemId);
-    void eliminarPersonaje(Personaje personaje);
+
+    void eliminar(Personaje personaje);
+
     void eliminarTodos();
-
-
-
 }

--- a/src/main/java/ar/edu/unq/unidad3/service/impl/ItemServiceImpl.java
+++ b/src/main/java/ar/edu/unq/unidad3/service/impl/ItemServiceImpl.java
@@ -17,19 +17,28 @@ public class ItemServiceImpl implements ItemService {
     }
 
     @Override
-    public void guardarItem(Item item) {
+    public void crear(Item item) {
         HibernateTransactionRunner.runTrx(() -> {
-            itemDAO.guardar(item);
+            itemDAO.crear(item);
             return null;
         });
     }
+
     @Override
-    public Collection<Item> allItems() {
-        return HibernateTransactionRunner.runTrx(() -> itemDAO.getAll());
+    public void actualizar(Item item) {
+        HibernateTransactionRunner.runTrx(() -> {
+            itemDAO.actualizar(item);
+            return null;
+        });
     }
 
     @Override
-    public void eliminarItem(Item item) {
+    public Collection<Item> recuperarTodos() {
+        return HibernateTransactionRunner.runTrx(() -> itemDAO.recuperarTodos());
+    }
+
+    @Override
+    public void eliminar(Item item) {
         HibernateTransactionRunner.runTrx(() -> {
             itemDAO.eliminar(item);
             return null;
@@ -45,20 +54,17 @@ public class ItemServiceImpl implements ItemService {
     }
 
     @Override
-    public Item heaviestItem() {
-        return HibernateTransactionRunner.runTrx(()
-                -> itemDAO.getHeaviestItem());
+    public Item getMasPesado() {
+        return HibernateTransactionRunner.runTrx(() -> itemDAO.getMasPesado());
     }
 
     @Override
-    public Collection<Item> getMasPesdos(int peso) {
-        return HibernateTransactionRunner.runTrx(()
-                -> itemDAO.getMasPesados(peso));
+    public Collection<Item> getMasPesados(int peso) {
+        return HibernateTransactionRunner.runTrx(() -> itemDAO.getMasPesados(peso));
     }
 
     @Override
     public Collection<Item> getItemsPersonajesDebiles(int vida) {
-        return HibernateTransactionRunner.runTrx(()
-                -> itemDAO.getItemsDePersonajesDebiles(vida));
+        return HibernateTransactionRunner.runTrx(() -> itemDAO.getItemsDePersonajesDebiles(vida));
     }
 }

--- a/src/main/java/ar/edu/unq/unidad3/service/impl/ItemServiceImpl.java
+++ b/src/main/java/ar/edu/unq/unidad3/service/impl/ItemServiceImpl.java
@@ -1,6 +1,7 @@
 package ar.edu.unq.unidad3.service.impl;
 
 import ar.edu.unq.unidad3.modelo.Item;
+import ar.edu.unq.unidad3.modelo.Personaje;
 import ar.edu.unq.unidad3.persistencia.dao.ItemDAO;
 import ar.edu.unq.unidad3.service.ItemService;
 import ar.edu.unq.unidad3.service.runner.HibernateTransactionRunner;
@@ -30,6 +31,11 @@ public class ItemServiceImpl implements ItemService {
             itemDAO.actualizar(item);
             return null;
         });
+    }
+
+    @Override
+    public Item recuperar(Long itemId) {
+        return HibernateTransactionRunner.runTrx(() -> itemDAO.recuperar(itemId));
     }
 
     @Override

--- a/src/main/java/ar/edu/unq/unidad3/service/impl/PersonajeServiceImpl.java
+++ b/src/main/java/ar/edu/unq/unidad3/service/impl/PersonajeServiceImpl.java
@@ -18,17 +18,24 @@ public class PersonajeServiceImpl implements PersonajeService {
     }
 
     @Override
-    public void guardarPersonaje(Personaje personaje) {
+    public void crear(Personaje personaje) {
         HibernateTransactionRunner.runTrx(() -> {
-            personajeDAO.guardar(personaje);
+            personajeDAO.crear(personaje);
             return null;
         });
     }
 
     @Override
-    public Personaje recuperarPersonaje(Long personajeId) {
-        return HibernateTransactionRunner.runTrx(()->
-            personajeDAO.recuperar(personajeId));
+    public void actualizar(Personaje personaje) {
+        HibernateTransactionRunner.runTrx(() -> {
+            personajeDAO.actualizar(personaje);
+            return null;
+        });
+    }
+
+    @Override
+    public Personaje recuperar(Long personajeId) {
+        return HibernateTransactionRunner.runTrx(() -> personajeDAO.recuperar(personajeId));
     }
 
     @Override
@@ -37,14 +44,14 @@ public class PersonajeServiceImpl implements PersonajeService {
             Personaje personaje = personajeDAO.recuperar(personajeId);
             Item item = itemDAO.recuperar(itemId);
             personaje.recoger(item);
-            personajeDAO.guardar(personaje);
+            personajeDAO.actualizar(personaje);
             return null;
         });
     }
 
     @Override
-    public void eliminarPersonaje(Personaje personaje) {
-        HibernateTransactionRunner.runTrx(()-> {
+    public void eliminar(Personaje personaje) {
+        HibernateTransactionRunner.runTrx(() -> {
             personajeDAO.eliminar(personaje);
             return null;
         });

--- a/src/main/java/ar/edu/unq/unidad3/service/runner/HibernateSessionContext.java
+++ b/src/main/java/ar/edu/unq/unidad3/service/runner/HibernateSessionContext.java
@@ -3,7 +3,7 @@ package ar.edu.unq.unidad3.service.runner;
 import org.hibernate.Session;
 
 public class HibernateSessionContext {
-    
+
     private static final ThreadLocal<Session> sessionThreadLocal = new ThreadLocal<>();
 
     public static void setCurrentSession(Session session) {

--- a/src/main/java/ar/edu/unq/unidad3/service/runner/HibernateSessionFactoryProvider.java
+++ b/src/main/java/ar/edu/unq/unidad3/service/runner/HibernateSessionFactoryProvider.java
@@ -4,11 +4,7 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.cfg.Configuration;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.sql.ResultSet;
+import java.sql.*;
 
 
 public class HibernateSessionFactoryProvider {
@@ -49,13 +45,6 @@ public class HibernateSessionFactoryProvider {
             INSTANCE = new HibernateSessionFactoryProvider();
         }
         return INSTANCE;
-    }
-
-    public static void destroy() {
-        if (INSTANCE != null && INSTANCE.sessionFactory != null) {
-            INSTANCE.sessionFactory.close();
-        }
-        INSTANCE = null;
     }
 
     private void createDatabaseIfNotExists(String databaseName, String user, String password, String host, String port) {

--- a/src/main/java/ar/edu/unq/unidad3/service/runner/HibernateTransactionRunner.java
+++ b/src/main/java/ar/edu/unq/unidad3/service/runner/HibernateTransactionRunner.java
@@ -8,7 +8,7 @@ public class HibernateTransactionRunner {
         Session session = HibernateSessionFactoryProvider.getInstance().createSession();
         HibernateSessionContext.setCurrentSession(session);
         var tx = session.beginTransaction();
-        
+
         try {
             T resultado = bloque.execute();
             tx.commit();

--- a/src/test/java/ar/edu/unq/unidad3/persistencia/dao/InventarioServiceTest.java
+++ b/src/test/java/ar/edu/unq/unidad3/persistencia/dao/InventarioServiceTest.java
@@ -33,27 +33,23 @@ public class InventarioServiceTest {
         );
 
         maguin = new Personaje("Maguin",  10, 70);
-        personajeService.guardarPersonaje(maguin);
+        personajeService.crear(maguin);
 
         debilucho = new Personaje("Debilucho", 1, 1000);
-        personajeService.guardarPersonaje(debilucho);
+        personajeService.crear(debilucho);
 
         tunica = new Item("Tunica", 100);
         baculo = new Item("Baculo", 50);
 
-        itemService.guardarItem(tunica);
-        itemService.guardarItem(baculo);
-
-
-
-
+        itemService.crear(tunica);
+        itemService.crear(baculo);
     }
 
     @Test
     void testRecoger() {
         personajeService.recoger(maguin.getId(), baculo.getId());
 
-        Personaje maguito = personajeService.recuperarPersonaje(maguin.getId());
+        Personaje maguito = personajeService.recuperar(maguin.getId());
         assertEquals("Maguin", maguito.getNombre());
 
         assertEquals(1, maguito.getInventario().size());
@@ -61,12 +57,12 @@ public class InventarioServiceTest {
         Item baculo = maguito.getInventario().iterator().next();
         assertEquals("Baculo", baculo.getNombre());
 
-        assertEquals(baculo.getOwner(), maguito);
+        assertEquals(baculo.getPoseedor(), maguito);
     }
 
     @Test
     void testGetAll() {
-        var items = itemService.allItems();
+        var items = itemService.recuperarTodos();
 
         assertEquals(2, items.size());
         assertTrue(items.contains(baculo));
@@ -74,10 +70,10 @@ public class InventarioServiceTest {
 
     @Test
     void testGetMasPesados() {
-        var items = itemService.getMasPesdos(10);
+        var items = itemService.getMasPesados(10);
         assertEquals(2, items.size());
 
-        var items2 = itemService.getMasPesdos(80);
+        var items2 = itemService.getMasPesados(80);
         assertEquals(1, items2.size());
     }
 
@@ -96,7 +92,7 @@ public class InventarioServiceTest {
 
     @Test
     void testGetMasPesado() {
-        Item item = itemService.heaviestItem();
+        Item item = itemService.getMasPesado();
         assertEquals("Tunica", item.getNombre());
     }
 
@@ -105,9 +101,33 @@ public class InventarioServiceTest {
         assertThrows(MuchoPesoException.class, () -> personajeService.recoger(maguin.getId(), tunica.getId()));
     }
 
+    @Test
+    void testActualizarPersonaje() {
+        maguin.setNombre("Maguito");
+        maguin.setVida(99);
+        personajeService.actualizar(maguin);
+
+        Personaje recuperado = personajeService.recuperar(maguin.getId());
+        assertEquals("Maguito", recuperado.getNombre());
+        assertEquals(99, recuperado.getVida());
+    }
+
+    @Test
+    void testActualizarItem() {
+        baculo.setNombre("Baculo Magico");
+        baculo.setPeso(10);
+        itemService.actualizar(baculo);
+
+        Item recuperado = itemService.recuperarTodos().stream()
+                .filter(i -> i.getId().equals(baculo.getId()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("Baculo Magico", recuperado.getNombre());
+        assertEquals(10, recuperado.getPeso());
+    }
+
     @AfterEach
     void cleanup() {
-
         itemService.eliminarTodos();
         personajeService.eliminarTodos();
     }

--- a/src/test/java/ar/edu/unq/unidad3/persistencia/dao/InventarioServiceTest.java
+++ b/src/test/java/ar/edu/unq/unidad3/persistencia/dao/InventarioServiceTest.java
@@ -61,11 +61,11 @@ public class InventarioServiceTest {
     }
 
     @Test
-    void testGetAll() {
+    void testRecuperarTodos() {
         var items = itemService.recuperarTodos();
 
         assertEquals(2, items.size());
-        assertTrue(items.contains(baculo));
+        assertTrue(items.stream().mapToLong(Item::getId).anyMatch(id -> id == baculo.getId()));
     }
 
     @Test

--- a/src/test/java/ar/edu/unq/unidad3/persistencia/dao/InventarioServiceTest.java
+++ b/src/test/java/ar/edu/unq/unidad3/persistencia/dao/InventarioServiceTest.java
@@ -118,10 +118,7 @@ public class InventarioServiceTest {
         baculo.setPeso(10);
         itemService.actualizar(baculo);
 
-        Item recuperado = itemService.recuperarTodos().stream()
-                .filter(i -> i.getId().equals(baculo.getId()))
-                .findFirst()
-                .orElseThrow();
+        Item recuperado = itemService.recuperar(baculo.getId());
         assertEquals("Baculo Magico", recuperado.getNombre());
         assertEquals(10, recuperado.getPeso());
     }


### PR DESCRIPTION
Que se modifica en este refactor:
- Cambiamos `save` por `persist` en el método crear (el `save` está deprecado según Hibernate).
- Agregamos métodos actualizar y tests.
- Cambiamos "guardar" por "crear".
- Los services ya no tienen métodos del tipo `recuperarPersonaje` o `recuperarItem`, son simplemente `recuperar`.
- Evitamos el spanglish en los métodos.
- Fomateo en TODOS los archivos.
- Sacamos método `destroy` del HibernateSessionFactory que no tenía uso.